### PR TITLE
Add generic loading component and project types

### DIFF
--- a/src/Componentes/CardSystem.tsx
+++ b/src/Componentes/CardSystem.tsx
@@ -1,23 +1,13 @@
-import React, { useState,useContext } from 'react';
+import React, { useState, useContext } from 'react';
 import { EditOutlined } from '@ant-design/icons';
-import { Avatar, Card,Tag,Row, Col  } from 'antd';
+import { Avatar, Card, Tag, Row, Col } from 'antd';
 import useLocalStorage from '../hooks/useLocalStorage';
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from 'react-router-dom';
 import { UserContext } from '../context/UserContext';
-interface TagsType{
-    id :number,
-    Tag:string;
-  }
-interface CardData {
-     Sistema: string;
-      Logo: string;
-      Descripcion: string;
-      id: number; 
-      fecha_registro:string;
-      detalle_tags:TagsType[];
-}
+import type { ProyectoResumen } from '../types/Proyecto';
+
 interface CardSystemProps {
-  data: CardData;
+  data: ProyectoResumen;
 }
 
 const CardSystem: React.FC<CardSystemProps> = ({ data }) => {

--- a/src/Componentes/ErrorMessage.tsx
+++ b/src/Componentes/ErrorMessage.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Alert } from 'antd';
+
+interface ErrorMessageProps {
+  message: string;
+}
+
+const ErrorMessage: React.FC<ErrorMessageProps> = ({ message }) => (
+  <Alert message={message} type="error" showIcon style={{ marginTop: '20vh' }} />
+);
+
+export default ErrorMessage;

--- a/src/Componentes/Loading.tsx
+++ b/src/Componentes/Loading.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Spin } from 'antd';
+import { SyncOutlined } from '@ant-design/icons';
+
+interface LoadingProps {
+  fullscreen?: boolean;
+}
+
+const Loading: React.FC<LoadingProps> = ({ fullscreen = false }) => {
+  const icon = <SyncOutlined style={{ fontSize: 48, color: 'rgba(32,93,93,255)' }} spin />;
+  return <Spin indicator={icon} fullscreen={fullscreen} />;
+};
+
+export default Loading;

--- a/src/Home/Home.tsx
+++ b/src/Home/Home.tsx
@@ -1,18 +1,20 @@
-import React,{useEffect,useState,useContext} from 'react'
-import { useNavigate } from "react-router-dom";
+import React, { useEffect, useState, useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { useGenerarPeticion } from '../Apis/apipeticiones';
 import CardSystem from '../Componentes/CardSystem';
-import { Row, Col,Spin,FloatButton,Divider } from 'antd';
-import { SyncOutlined,PlusOutlined  } from '@ant-design/icons';
+import Loading from '../Componentes/Loading';
+import { Row, Col, FloatButton, Divider } from 'antd';
+import { PlusOutlined } from '@ant-design/icons';
 import useLocalStorage from '../hooks/useLocalStorage';
 import { UserContext } from '../context/UserContext';
+import type { ProyectoResumen } from '../types/Proyecto';
 import './home.css'
 
 const Home: React.FC = () => {
   const generarPeticion = useGenerarPeticion();
-  const { setModuloSistema,addModulo } = useContext(UserContext)!;
-  const [datasistemas, setDatasistemas] = useState<DataType[]>([]); 
+  const { setModuloSistema, addModulo } = useContext(UserContext)!;
+  const [datasistemas, setDatasistemas] = useState<ProyectoResumen[]>([]);
   const [__idProyecto, setIdProyecto] = useLocalStorage<number>('id_proyecto', 0);
   const [loading, setLoading] = useState(true);
  
@@ -28,25 +30,6 @@ const Home: React.FC = () => {
     navigate('/Registro')
   }
   
-  interface TagsType{
-    id :number,
-    Tag:string;
-  }
-  interface DataType {
-     
-      Sistema: string;
-      Logo: string;
-      Descripcion: string;
-      id: number; 
-      fecha_registro:string;
-      detalle_tags:TagsType[];
-      
-    }
-  const customIcon = (
-    
-    <SyncOutlined style={{ fontSize: 48, color: "rgba(32,93,93,255)" }} spin />
-
-    );
   useEffect(() => {
     setModuloSistema([])
     addModulo({ title: 'Home' });
@@ -83,23 +66,9 @@ const Home: React.FC = () => {
       <div>
         
         
-        {/* {
-            loading ?(
-                // <Spin percent= 'auto'  size="large" fullscreen className="custom-spinner"  />
-                <Spin indicator={customIcon} fullscreen />
-            ):(
-                <Row gutter={[16, 16]}>
-                  {datasistemas.map((item) => (
-                  <Col key={item.id} xs={24} sm={12} md={8}>
-                      <CardSystem data={item} />
-                  </Col>
-                  ))}
-              </Row>
-            )
-        } */}
 
         {loading ? (
-            <Spin indicator={customIcon} fullscreen />
+            <Loading fullscreen />
           ) : (
             <div>
               {(() => {

--- a/src/InicioSesion/InicioSesion.tsx
+++ b/src/InicioSesion/InicioSesion.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
-import { Button, Form, Input, Descriptions, message, Spin } from "antd";
-import { useNavigate } from "react-router-dom";
-import { SyncOutlined } from '@ant-design/icons';
+import { Button, Form, Input, Descriptions, message } from 'antd';
+import { useNavigate } from 'react-router-dom';
+import Loading from '../Componentes/Loading';
 import InicioSesionApi from '../Apis/apiiniciosesion';
 import { usePeticionComprobacion } from '../Apis/apicomprobarsesion';
 import useLocalStorage from '../hooks/useLocalStorage';
@@ -32,9 +32,6 @@ const InicioSesion: React.FC = () => {
         });
     };
 
-    const customIcon = (
-        <SyncOutlined style={{ fontSize: 48, color: "rgba(32,93,93,255)" }} spin />
-    );
 
     const onFinish: FormProps<FieldType>['onFinish'] = async (values) => {
         const pass = values.password
@@ -80,7 +77,7 @@ const InicioSesion: React.FC = () => {
         }}>
 
             {contextHolder}
-            {loading ? (<Spin indicator={customIcon} fullscreen />) : (
+            {loading ? (<Loading fullscreen />) : (
                 <>
                     <Descriptions title="INGRESO AL SISTEMA" />
                     <Form

--- a/src/types/Proyecto.ts
+++ b/src/types/Proyecto.ts
@@ -1,0 +1,13 @@
+export interface TagsType {
+  id: number;
+  Tag: string;
+}
+
+export interface ProyectoResumen {
+  Sistema: string;
+  Logo: string;
+  Descripcion: string;
+  id: number;
+  fecha_registro: string;
+  detalle_tags: TagsType[];
+}


### PR DESCRIPTION
## Summary
- add reusable `Loading` component and `ErrorMessage`
- share project types via `src/types/Proyecto.ts`
- refactor `Home` and `InicioSesion` to use the new component and types
- simplify `CardSystem` props

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685d37923ca483318322694c490465b3